### PR TITLE
PHP 8.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.phpcs-cache
 /vendor/
+/.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f071f1a814e8c461ab4f199b37043570",
+    "content-hash": "2d124cc77237e8c97013e84dfbde4e44",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -422,7 +422,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3"
+        "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"


### PR DESCRIPTION

Q | A
-- | --
Documentation | no
Bugfix | no
BC Break | no
New Feature | yes
RFC | no
QA | yes

### Description
Fixes issue #2 - PHP 8.0 support.

I am planning to add PHP 8 support for the following packages:

- laminas-api-tools/api-tools-provider
- laminas-api-tools/api-tools-versioning
- laminas-api-tools/api-tools-api-problem
- laminas-api-tools/api-tools-content-negotiation
- laminas-api-tools/api-tools-content-validation
- laminas-api-tools/api-tools-oauth2
- laminas-api-tools/api-tools-mvc-auth
- laminas-api-tools/api-tools-rest
- laminas-api-tools/api-tools-rpc
- laminas-api-tools/api-tools
- laminas-api-tools/api-tools-admin
