### PR TITLE
Normalize composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "laminas-api-tools/api-tools-provider",
     "description": "Laminas API Tools interfaces",
-    "license": "BSD-3-Clause",
     "keywords": [
         "laminas",
         "api-tools",
@@ -9,26 +8,21 @@
         "framework"
     ],
     "homepage": "https://api-tools.getlaminas.org",
-    "support": {
-        "docs": "https://api-tools.getlaminas.org/documentation",
-        "issues": "https://github.com/laminas-api-tools/api-tools-provider/issues",
-        "source": "https://github.com/laminas-api-tools/api-tools-provider",
-        "rss": "https://github.com/laminas-api-tools/api-tools-provider/releases.atom",
-        "chat": "https://laminas.dev/chat",
-        "forum": "https://discourse.laminas.dev"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-    },
+    "license": "BSD-3-Clause",
     "require": {
         "php": "^5.6 || ^7.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
+    "replace": {
+        "zfcampus/zf-apigility-provider": "^1.3.0"
+    },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0"
     },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {},
     "autoload": {
         "psr-4": {
             "Laminas\\ApiTools\\Provider\\": "src/"
@@ -41,7 +35,12 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf"
     },
-    "replace": {
-        "zfcampus/zf-apigility-provider": "^1.3.0"
+    "support": {
+        "issues": "https://github.com/laminas-api-tools/api-tools-provider/issues",
+        "forum": "https://discourse.laminas.dev",
+        "chat": "https://laminas.dev/chat",
+        "source": "https://github.com/laminas-api-tools/api-tools-provider",
+        "docs": "https://api-tools.getlaminas.org/documentation",
+        "rss": "https://github.com/laminas-api-tools/api-tools-provider/releases.atom"
     }
 }


### PR DESCRIPTION
**[QA]**
* Normalize `composer.json` and/or update `composer.lock`
    - Restructure `composer.json` according to the underlying [JSON schema](https://getcomposer.org/schema.json).
    - Prevent inconsistencies between all (200+) repositories across all 3 GitHub organizations (`laminas`, `mezzio`, and `laminas-api-tools`).